### PR TITLE
Sloppy nav bar fixed,

### DIFF
--- a/css/ballerina-io.css
+++ b/css/ballerina-io.css
@@ -1312,7 +1312,7 @@ padding-right: 0;
     }
 }
 
-@media screen and (max-width: 768px) {
+@media screen and (max-width: 991px) {
     .navbar-header {
         width: 100% !important;
     }
@@ -1430,7 +1430,7 @@ padding-right: 0;
     }
 }
 
-@media (min-width: 768px) {
+@media (min-width: 991px) {
     #iBallerinaFooter .cBallerina-io-right-col p {
         padding-left: 0;
         padding-top: 20px;
@@ -1454,7 +1454,7 @@ padding-right: 0;
     }
 }
 
-@media (min-width: 992px) {
+@media (min-width: 991px) {
     #iBallerinaFooter .cBallerina-io-right-col p {
         padding-left: 40px;
         padding-top: 0;
@@ -1479,7 +1479,7 @@ padding-right: 0;
     }
 }
 
-@media (max-width: 768px) {
+@media (max-width: 991px) {
     .navbar-nav>li:last-child a.cSerachIcon {
         display: none;
     }
@@ -1496,7 +1496,7 @@ padding-right: 0;
     }
 }
 
-@media (max-width: 768px) {
+@media (max-width: 991px) {
     .navbar-nav>li:last-child a.cSerachIcon {
         display: none;
     }
@@ -1607,4 +1607,42 @@ text-shadow: 0 1px 0 rgba(255,255,255,.25);
 }
 .select-css option {
 	font-weight:normal;
+}
+
+@media (max-width: 991px) {
+    .navbar-header {
+        float: none;
+    }
+    .navbar-toggle {
+        display: block;
+    }
+    .navbar-collapse {
+        border-top: 1px solid transparent;
+        box-shadow: inset 0 1px 0 rgba(255,255,255,0.1);
+    }
+    .navbar-collapse.collapse {
+        display: none!important;
+    }
+    .navbar-nav {
+        float: none!important;
+        margin: 7.5px -15px;
+    }
+    .navbar-nav>li {
+        float: none;
+    }
+    .navbar-nav>li>a {
+        padding-top: 10px;
+        padding-bottom: 10px;
+    }
+    .navbar-text {
+        float: none;
+        margin: 15px 0;
+    }
+    /* since 3.1.0 */
+    .navbar-collapse.collapse.in { 
+        display: block!important;
+    }
+    .collapsing {
+        overflow: hidden!important;
+    }
 }


### PR DESCRIPTION
## Purpose
When we navigate to [learn page](https://ballerina.io/learn/) the navigation bar is become sloppy between
768px to 991px screen range.

> Fixes
I override the [Navbar collapse point](https://github.com/ASMohamedRiFaheemAnver/ballerina-platform.github.io/commit/5c3c7c90e091fcf097939791d4c4ebf7a032b2db).

## Check List
You can check this [picture](https://drive.google.com/file/d/1wQEyodlKv99412UOMHbFhkkGHo6HlzYE/view?usp=sharing).
