### PR TITLE
Fix the Broken Link in the Network in the Language Page

### DIFF
--- a/why/the-network-in-the-language.md
+++ b/why/the-network-in-the-language.md
@@ -319,7 +319,7 @@ twitter:Status|error status = twitterClient->tweet("Hello World!");
                                        <td><a href="https://ballerina.io/v1-2/learn/by-example/secured-client-with-basic-auth.html">Basic Auth</a></td>
                                     </tr>
                                     <tr>
-                                       <td><a href="https://ballerina.io/v1-2/learn/by-example/secured-service-with-jwt.html">JWT</a></td>
+                                       <td><a href="https://ballerina.io/v1-2/learn/by-example/secured-service-with-jwt-auth.html">JWT</a></td>
                                        <td><a href="https://ballerina.io/v1-2/learn/by-example/secured-client-with-jwt-auth.html">JWT</a></td>
                                     </tr>
                                     <tr>


### PR DESCRIPTION
## Purpose
This is to fix a broken link in [1].

[1] https://ballerina.io/why/the-network-in-the-language/
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
