### PR TITLE
Fix 2022R3 spec broken link

### DIFF
--- a/spec/lang/2022R3/index.html
+++ b/spec/lang/2022R3/index.html
@@ -8633,7 +8633,7 @@ expression, except that it is used for a client object method with the
 <span class="ntdfn" id="resource-access-rest-segment">resource-access-rest-segment</span> := <code>[</code> <code>...</code> <a href="#expression"><span class="ntref">expression</span></a> <code>]</code>
 </pre>
 <p>
-A <code>client-resource-access-action</code> performs a <a href="resources_defn">resource access operation</a> on a client object. An
+A <code>client-resource-access-action</code> performs a <a href="#resources_defn">resource access operation</a> on a client object. An
 omitted <code>resource-method-name</code> defaults to <code>get</code>; if the
 parentheses and the <code>arg-list</code> are omitted, then they default to
 <code>()</code>, with arguments being defaulted as usual.


### PR DESCRIPTION
## Purpose
Fix 2022R3 spec broken link.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
